### PR TITLE
Produce valid config.json, fix trailing command after grpc_tls

### DIFF
--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -35,7 +35,7 @@
         "grpc": "{{ consul_addresses.grpc }}",
         {% endif %}
         {% if consul_version is version_compare('1.14.0', '>=') %}
-        "grpc_tls": "{{ consul_addresses.grpc_tls }}",
+        "grpc_tls": "{{ consul_addresses.grpc_tls }}"
         {% endif %}
     },
     {## Ports Used ##}


### PR DESCRIPTION
##### SUMMARY

Removes trailing comma after `grpc_tls` in addresses configuration block.

The trailing comma makes the generated JSON invalid and breaks tools like `jq`; currently the template produces:
```
  "addresses": {
    "dns": "0.0.0.0",
    "http": "0.0.0.0",
    "https": "0.0.0.0",
    "grpc": "0.0.0.0",
    "grpc_tls": "0.0.0.0",
  },
```

`grpc_tls` should not have trailing comma.

Fixes https://github.com/ansible-collections/ansible-consul/issues/572

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

Config template.

