### PR TITLE
Format config.json properly without double newline encoding

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -6,7 +6,7 @@
     dest: "{{ config_item.dest }}"
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
-    content: "{{ lookup('template', consul_config_template_path, convert_data=True) | to_nice_json }}"
+    content: "{{ lookup('template', consul_config_template_path, convert_data=True) | from_json | to_nice_json }}"
     mode: "0600"
   with_items:
     - dest: "{{ consul_config_path }}/config.json"


### PR DESCRIPTION
##### SUMMARY

Produce a valid json config on latest Ansible versions.

Fixes https://github.com/ansible-collections/ansible-consul/issues/621

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME

Task

##### ADDITIONAL INFORMATION

The produced json is not valid

```
cat /etc/consul/config.json
"{\n    \n            \"datacenter\": \"dc1\",\n    \"domain\": \"consul\",\n                \"performance\": {\"raft_multiplier\": 1, \"leave_drain_time\": \"5s\", \"rpc_hold_timeout\": \"7s\"},\n\n        \"bind_addr\":
[...]
```

Validate json, and then write out json properly.

Requires https://github.com/ansible-collections/ansible-consul/pull/620 as otherwise the produced config is not valid.
