### PR TITLE
Skip creating the home folder for consul user

### DIFF
--- a/tasks/user_group.yml
+++ b/tasks/user_group.yml
@@ -17,6 +17,7 @@
     comment: Consul user
     group: "{{ consul_group }}"
     system: true
+    create_home: false
   when:
     - consul_manage_user | bool
     - not consul_install_from_repo | bool


### PR DESCRIPTION
Skip creating the home folder for consul user

##### SUMMARY
System users don't need home directories since they won't be logging in interactively. This change adds `create_home: false` to the Consul user creation task to prevent unnecessary home directory creation, following best practices for system service accounts.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
consul_user (user creation task)

##### ADDITIONAL INFORMATION
System users are created with `system: true` and are intended to run services rather than support interactive login sessions. Creating a home director is unnecessary.

**Before:**
- Home directory would be created at `/home/{{ consul_user }}` by default

**After:**
- No home directory is created for the Consul system user
- The account remains fully functional for running the Consul service